### PR TITLE
Add argument parsing

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,7 +1,10 @@
 #!/usr/bin/env python
 import os
 import csv
+import argparse
+import pathlib
 from PIL import Image, ImageDraw, ImageFont
+
 
 class CertificateGenerator(object):
     def __init__(self, template_path, font_path, certificate_path):
@@ -15,9 +18,9 @@ class CertificateGenerator(object):
     
         certificate = Image.open(self.template_path)
         draw = ImageDraw.Draw(certificate)
-        font = ImageFont.truetype(self.font_path, size=50)
-        date_font = ImageFont.truetype(self.font_path, size=30)
-        certificate_number_font = ImageFont.truetype(self.font_path, size=30)
+        font = ImageFont.truetype(str(self.font_path), size=50)
+        date_font = ImageFont.truetype(str(self.font_path), size=30)
+        certificate_number_font = ImageFont.truetype(str(self.font_path), size=30)
     
         width, height = certificate.size
     
@@ -58,16 +61,20 @@ def create_directory(path):
         os.mkdir(path)
 
 def run():
-    template_path = 'template/certificate_template.png'
-    font_path = 'font/arial.ttf'
-    certificate_path = 'certificates/certificate.png'
-    data_path = 'data/data.csv'
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--template_path', type=pathlib.Path, required=False, default='template/certificate_template.png')
+    parser.add_argument('--font_path', type=pathlib.Path, default='font/arial.ttf')
+    parser.add_argument('--certificate_path', type=pathlib.Path, default='certificates/certificate.png')
+    parser.add_argument('--data_path', type=pathlib.Path, default='data/data.csv')
 
-    create_directory('certificates')
+    args = parser.parse_args()
 
-    generator = CertificateGenerator(template_path, font_path, certificate_path)
+    certificates_directory = os.path.dirname(args.certificate_path)
+    create_directory(certificates_directory)
 
-    with open(data_path, newline='') as csv_file:
+    generator = CertificateGenerator(args.template_path, args.font_path, args.certificate_path)
+
+    with open(args.data_path, newline='') as csv_file:
         csv_reader = csv.reader(csv_file, delimiter=',')
         for row in csv_reader:
             name, course, date, certificate_number = row

--- a/main.py
+++ b/main.py
@@ -3,52 +3,53 @@ import os
 import csv
 from PIL import Image, ImageDraw, ImageFont
 
-template_path = 'template/certificate_template.png'
-font_path = 'font/arial.ttf'
-certificate_path = 'certificates/certificate.png'
-data_path = 'data/data.csv'
+class CertificateGenerator(object):
+    def __init__(self, template_path, font_path, certificate_path):
+        self.template_path = template_path
+        self.font_path = font_path
+        self.certificate_path = certificate_path
 
-def generate_certificate(name, course, date, certificate_number):
-    if not os.path.isfile(template_path):
-        raise FileNotFoundError('No template')
-
-    certificate = Image.open(template_path)
-    draw = ImageDraw.Draw(certificate)
-    font = ImageFont.truetype(font_path, size=50)
-    date_font = ImageFont.truetype(font_path, size=30)
-    certificate_number_font = ImageFont.truetype(font_path, size=30)
-
-    width, height = certificate.size
-
-    name_width, name_height = draw.textsize(name, font=font)
-
-    date_width, date_height = draw.textsize(date, font=date_font)
-
-    certificate_number_width, certificate_number_height = draw.textsize(certificate_number, font=certificate_number_font)
-
-    course_width, course_height = draw.textsize(course, font=font)
-
-    name_x = (width - name_width) / 2
-    name_y = (height - name_height) / 2
-
-    date_x = (width - date_width) / 2
-    date_y = (height - date_height) / 2 + 100
-
-    certificate_number_x = (width - certificate_number_width) / 2
-    certificate_number_y = (height - certificate_number_height) / 2 + 150
-
-    course_x = (width - course_width) / 2
-    course_y = (height - course_height) / 2 + 50
-
-    draw.text((name_x, name_y), name, fill='rgb(0, 0, 0)', font=font)
-
-    draw.text((date_x, date_y), date, fill='rgb(0, 0, 0)', font=date_font)
-
-    draw.text((certificate_number_x, certificate_number_y), certificate_number, fill='rgb(0, 0, 0)', font=certificate_number_font)
-
-    draw.text((course_x, course_y), course, fill='rgb(0, 0, 0)', font=font)
-
-    certificate.save(certificate_path)
+    def generate_certificate(self, name, course, date, certificate_number):
+        if not os.path.isfile(self.template_path):
+            raise FileNotFoundError('No template')
+    
+        certificate = Image.open(self.template_path)
+        draw = ImageDraw.Draw(certificate)
+        font = ImageFont.truetype(self.font_path, size=50)
+        date_font = ImageFont.truetype(self.font_path, size=30)
+        certificate_number_font = ImageFont.truetype(self.font_path, size=30)
+    
+        width, height = certificate.size
+    
+        name_width, name_height = draw.textsize(name, font=font)
+    
+        date_width, date_height = draw.textsize(date, font=date_font)
+    
+        certificate_number_width, certificate_number_height = draw.textsize(certificate_number, font=certificate_number_font)
+    
+        course_width, course_height = draw.textsize(course, font=font)
+    
+        name_x = (width - name_width) / 2
+        name_y = (height - name_height) / 2
+    
+        date_x = (width - date_width) / 2
+        date_y = (height - date_height) / 2 + 100
+    
+        certificate_number_x = (width - certificate_number_width) / 2
+        certificate_number_y = (height - certificate_number_height) / 2 + 150
+    
+        course_x = (width - course_width) / 2
+        course_y = (height - course_height) / 2 + 50
+    
+        draw.text((name_x, name_y), name, fill='rgb(0, 0, 0)', font=font)
+    
+        draw.text((date_x, date_y), date, fill='rgb(0, 0, 0)', font=date_font)
+    
+        draw.text((certificate_number_x, certificate_number_y), certificate_number, fill='rgb(0, 0, 0)', font=certificate_number_font)
+    
+        draw.text((course_x, course_y), course, fill='rgb(0, 0, 0)', font=font)
+    
+        certificate.save(self.certificate_path)
 
 def create_directory(path):
     if os.path.isdir(path):
@@ -57,13 +58,20 @@ def create_directory(path):
         os.mkdir(path)
 
 def run():
+    template_path = 'template/certificate_template.png'
+    font_path = 'font/arial.ttf'
+    certificate_path = 'certificates/certificate.png'
+    data_path = 'data/data.csv'
+
     create_directory('certificates')
+
+    generator = CertificateGenerator(template_path, font_path, certificate_path)
 
     with open(data_path, newline='') as csv_file:
         csv_reader = csv.reader(csv_file, delimiter=',')
         for row in csv_reader:
             name, course, date, certificate_number = row
-            generate_certificate(name, course, date, certificate_number)
+            generator.generate_certificate(name, course, date, certificate_number)
 
     
 

--- a/main.py
+++ b/main.py
@@ -57,14 +57,14 @@ def read_csv():
             name, course, date, certificate_number = row
             generate_certificate(name, course, date, certificate_number)
 
-def create_directory():
-    if os.path.isdir('certificates'):
-        print('Directory exits')
+def create_directory(path):
+    if os.path.isdir(path):
+        print(f"{path} directory exits")
     else:
-        os.mkdir('certificates')
+        os.mkdir(path)
 
 def run():
-    create_directory()
+    create_directory('certificates')
     read_csv()
 
     

--- a/main.py
+++ b/main.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 from PIL import Image, ImageDraw, ImageFont
 import os
 import csv
@@ -8,46 +9,46 @@ certificate_path = 'certificates/certificate.png'
 data_path = 'data/data.csv'
 
 def generate_certificate(name, course, date, certificate_number):
-    if os.path.isfile(template_path):
-        certificate = Image.open(template_path)
-        draw = ImageDraw.Draw(certificate)
-        font = ImageFont.truetype(font_path, size=50)
-        date_font = ImageFont.truetype(font_path, size=30)
-        certificate_number_font = ImageFont.truetype(font_path, size=30)
-
-        width, height = certificate.size
-
-        name_width, name_height = draw.textsize(name, font=font)
-
-        date_width, date_height = draw.textsize(date, font=date_font)
-
-        certificate_number_width, certificate_number_height = draw.textsize(certificate_number, font=certificate_number_font)
-
-        course_width, course_height = draw.textsize(course, font=font)
-
-        name_x = (width - name_width) / 2
-        name_y = (height - name_height) / 2
-
-        date_x = (width - date_width) / 2
-        date_y = (height - date_height) / 2 + 100
-
-        certificate_number_x = (width - certificate_number_width) / 2
-        certificate_number_y = (height - certificate_number_height) / 2 + 150
-
-        course_x = (width - course_width) / 2
-        course_y = (height - course_height) / 2 + 50
-
-        draw.text((name_x, name_y), name, fill='rgb(0, 0, 0)', font=font)
-
-        draw.text((date_x, date_y), date, fill='rgb(0, 0, 0)', font=date_font)
-
-        draw.text((certificate_number_x, certificate_number_y), certificate_number, fill='rgb(0, 0, 0)', font=certificate_number_font)
-
-        draw.text((course_x, course_y), course, fill='rgb(0, 0, 0)', font=font)
-
-        certificate.save(certificate_path)
-    else:
+    if not os.path.isfile(template_path):
         raise FileNotFoundError('No template')
+
+    certificate = Image.open(template_path)
+    draw = ImageDraw.Draw(certificate)
+    font = ImageFont.truetype(font_path, size=50)
+    date_font = ImageFont.truetype(font_path, size=30)
+    certificate_number_font = ImageFont.truetype(font_path, size=30)
+
+    width, height = certificate.size
+
+    name_width, name_height = draw.textsize(name, font=font)
+
+    date_width, date_height = draw.textsize(date, font=date_font)
+
+    certificate_number_width, certificate_number_height = draw.textsize(certificate_number, font=certificate_number_font)
+
+    course_width, course_height = draw.textsize(course, font=font)
+
+    name_x = (width - name_width) / 2
+    name_y = (height - name_height) / 2
+
+    date_x = (width - date_width) / 2
+    date_y = (height - date_height) / 2 + 100
+
+    certificate_number_x = (width - certificate_number_width) / 2
+    certificate_number_y = (height - certificate_number_height) / 2 + 150
+
+    course_x = (width - course_width) / 2
+    course_y = (height - course_height) / 2 + 50
+
+    draw.text((name_x, name_y), name, fill='rgb(0, 0, 0)', font=font)
+
+    draw.text((date_x, date_y), date, fill='rgb(0, 0, 0)', font=date_font)
+
+    draw.text((certificate_number_x, certificate_number_y), certificate_number, fill='rgb(0, 0, 0)', font=certificate_number_font)
+
+    draw.text((course_x, course_y), course, fill='rgb(0, 0, 0)', font=font)
+
+    certificate.save(certificate_path)
 
 def read_csv():
     with open(data_path, newline='') as csv_file:

--- a/main.py
+++ b/main.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
-from PIL import Image, ImageDraw, ImageFont
 import os
 import csv
+from PIL import Image, ImageDraw, ImageFont
 
 template_path = 'template/certificate_template.png'
 font_path = 'font/arial.ttf'

--- a/main.py
+++ b/main.py
@@ -50,13 +50,6 @@ def generate_certificate(name, course, date, certificate_number):
 
     certificate.save(certificate_path)
 
-def read_csv():
-    with open(data_path, newline='') as csv_file:
-        csv_reader = csv.reader(csv_file, delimiter=',')
-        for row in csv_reader:
-            name, course, date, certificate_number = row
-            generate_certificate(name, course, date, certificate_number)
-
 def create_directory(path):
     if os.path.isdir(path):
         print(f"{path} directory exits")
@@ -65,7 +58,12 @@ def create_directory(path):
 
 def run():
     create_directory('certificates')
-    read_csv()
+
+    with open(data_path, newline='') as csv_file:
+        csv_reader = csv.reader(csv_file, delimiter=',')
+        for row in csv_reader:
+            name, course, date, certificate_number = row
+            generate_certificate(name, course, date, certificate_number)
 
     
 


### PR DESCRIPTION
Contains small refactors and the ability to change parameters via CLI

```bash
poetry run python main.py -h
usage: main.py [-h] [--template_path TEMPLATE_PATH] [--font_path FONT_PATH] [--certificate_path CERTIFICATE_PATH] [--data_path DATA_PATH]

options:
  -h, --help            show this help message and exit
  --template_path TEMPLATE_PATH
  --font_path FONT_PATH
  --certificate_path CERTIFICATE_PATH
  --data_path DATA_PATH
```

Default paths are kept and everything is optional.